### PR TITLE
Closes #138 #140 - Several updates to Zetten

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,1 @@
+site.yml

--- a/ansible/accumulo.yml
+++ b/ansible/accumulo.yml
@@ -1,0 +1,13 @@
+- hosts: all
+  roles:
+    - accumulo
+- hosts: accumulomaster
+  tasks:
+    - include: roles/accumulo/tasks/init-accumulo.yml
+  handlers:
+    - name: "initialize accumulo"
+      command: "{{ accumulo_home }}/bin/accumulo init --clear-instance-name --instance-name {{ accumulo_instance }} --password {{ accumulo_password }}"
+    - include: roles/accumulo/handlers/init-accumulo.yml
+- hosts: accumulo
+  tasks:
+    - include: roles/accumulo/tasks/start-accumulo.yml

--- a/ansible/common.yml
+++ b/ansible/common.yml
@@ -15,18 +15,12 @@
     - include: roles/common/tasks/drives.yml
   handlers:
     - name: "update network settings"
-      command: /sbin/ifup-local {{ network_interface }} 
-- hosts: metrics
-  become: yes
-  roles:
-    - influxdb
-    - grafana
+      command: /sbin/ifup-local {{ network_interface }}
 - hosts: all
   roles:
     - spark
     - hadoop
     - zookeeper
-    - accumulo
 - hosts: namenode
   tasks:
     - include: roles/hadoop/tasks/start-hdfs.yml
@@ -37,15 +31,3 @@
 - hosts: zookeepers
   tasks:
     - include: roles/zookeeper/tasks/start-zookeeper.yml
-- hosts: accumulomaster
-  tasks:
-    - include: roles/accumulo/tasks/init-accumulo.yml
-  handlers:
-    - name: "initialize accumulo"
-      command: "{{ accumulo_home }}/bin/accumulo init --clear-instance-name --instance-name {{ accumulo_instance }} --password {{ accumulo_password }}"
-- hosts: accumulo
-  tasks:
-    - include: roles/accumulo/tasks/start-accumulo.yml
-- hosts: fluo
-  roles:
-    - fluo

--- a/ansible/fluo.yml
+++ b/ansible/fluo.yml
@@ -1,0 +1,3 @@
+- hosts: fluo
+  roles:
+    - fluo

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -19,5 +19,6 @@ spark_tarball: spark-{{ spark_bin_version }}.tgz
 tarballs_dir: "{{ cluster_basedir }}/tarballs"
 worker_data_dirs: "{{ node_type_map['worker'].mounts }}"
 zookeeper_connect: "{{ groups['zookeepers']|join(',') }}"
+zookeeper_client_port: '2181'
 zookeeper_home: "{{ install_dir }}/zookeeper-{{ zookeeper_version }}"
 zookeeper_tarball: zookeeper-{{ zookeeper_version }}.tar.gz

--- a/ansible/kill.yml
+++ b/ansible/kill.yml
@@ -1,3 +1,15 @@
+- hosts: mesosmaster
+  become: yes
+  tasks:
+    - name: "stop mesos master"
+      service: name=mesos-master state=stopped
+      when: "'mesosmaster' in groups"
+- hosts: workers
+  become: yes
+  tasks:
+    - name: "stop mesos slaves"
+      service: name=mesos-slave state=stopped
+      when: "'mesosmaster' in groups"
 - hosts: all
   become: yes
   tasks:

--- a/ansible/mesos.yml
+++ b/ansible/mesos.yml
@@ -1,0 +1,14 @@
+- hosts: all
+  become: yes
+  roles:
+    - mesos
+- hosts: mesosmaster
+  become: yes
+  tasks:
+    - name: "mesos master is running"
+      service: name=mesos-master state=started
+- hosts: workers
+  become: yes
+  tasks:
+    - name: "mesos slaves are running"
+      service: name=mesos-slave state=started

--- a/ansible/metrics.yml
+++ b/ansible/metrics.yml
@@ -1,0 +1,5 @@
+- hosts: metrics
+  become: yes
+  roles:
+    - influxdb
+    - grafana

--- a/ansible/roles/common/tasks/os.yml
+++ b/ansible/roles/common/tasks/os.yml
@@ -7,8 +7,10 @@
 - name: "configure network settings for spark"
   copy: src=roles/common/files/ifup-local dest=/sbin/ifup-local mode=0755
   notify: "update network settings"
-- name: "configure shell"
+- name: "configure user shell"
   template: src=roles/common/templates/{{ item }} dest=/home/{{ cluster_user }}/.{{ item }} owner={{ cluster_user }} group={{ cluster_user }} mode=0644
   with_items:
     - bashrc
     - bash_profile
+- name: "configure root shell"
+  template: src=roles/common/templates/root_bashrc dest=/root/.bashrc mode=0644

--- a/ansible/roles/common/templates/root_bashrc
+++ b/ansible/roles/common/templates/root_bashrc
@@ -5,6 +5,7 @@ if [ -f /etc/bashrc ]; then
   . /etc/bashrc
 fi
 
+# User specific aliases and functions
 export JAVA_HOME={{ java_home }}
 export HADOOP_PREFIX={{ hadoop_prefix }}
 export HADOOP_HOME=$HADOOP_PREFIX
@@ -14,9 +15,17 @@ export SPARK_HOME={{ spark_home }}
 export ACCUMULO_HOME={{ accumulo_home }}
 export FLUO_HOME={{ fluo_home }}
 
-alias ssh='ssh -A'
-alias cdh='cd {{ hadoop_prefix }}'
-alias cdz='cd {{ zookeeper_home }}'
-alias cda='cd {{ accumulo_home }}'
-alias cdf='cd {{ fluo_home }}'
-alias ashell='{{ accumulo_home }}/bin/accumulo shell -u root -p {{ accumulo_password }}'
+PATH=$JAVA_HOME/bin:$PATH
+PATH=$PATH:{{ accumulo_home }}/bin
+PATH=$PATH:{{ fluo_home }}/bin
+PATH=$PATH:{{ hadoop_prefix }}/bin
+PATH=$PATH:{{ hadoop_prefix }}/sbin
+PATH=$PATH:{{ hub_home }}/bin
+PATH=$PATH:{{ maven_home }}/bin
+PATH=$PATH:{{ spark_home }}/bin
+PATH=$PATH:{{ zookeeper_home }}/bin
+export PATH
+
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'

--- a/ansible/roles/mesos/defaults/main.yml
+++ b/ansible/roles/mesos/defaults/main.yml
@@ -1,0 +1,6 @@
+mesos_version: 0.28.1
+mesosphere_yum_repo: http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm
+mesos_zookeeper_path: "/mesos"
+mesos_zookeeper_hosts: "{{ groups.zookeepers | join(':' + zookeeper_client_port + ',')  }}:{{ zookeeper_client_port  }}"
+mesos_zookeeper_connect: "zk://{{ mesos_zookeeper_hosts }}{{ mesos_zookeeper_path }}"
+mesos_quorum: 1

--- a/ansible/roles/mesos/tasks/main.yml
+++ b/ansible/roles/mesos/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: "add mesosphere repo"
+  yum: name={{ mesosphere_yum_repo }} state=present
+- name: "install mesos"
+  yum: name={{item}} state=present
+  with_items:
+    - mesos-{{mesos_version}}
+- name: "configure /etc/mesos"
+  template: src={{ item }} dest=/etc/mesos/{{ item }}
+  with_items:
+    - zk
+    - quorum
+- name: "configure /etc/default"
+  template: src={{ item }} dest=/etc/default/{{ item }}
+  with_items:
+    - mesos-master
+    - mesos-slave

--- a/ansible/roles/mesos/templates/mesos-master
+++ b/ansible/roles/mesos/templates/mesos-master
@@ -1,0 +1,3 @@
+RT=5050
+ZK=`cat /etc/mesos/zk`
+CLUSTER=zetten_mesos

--- a/ansible/roles/mesos/templates/mesos-slave
+++ b/ansible/roles/mesos/templates/mesos-slave
@@ -1,0 +1,3 @@
+MASTER=`cat /etc/mesos/zk`
+MESOS_HADOOP_HOME={{ hadoop_prefix }}
+JAVA_HOME={{ java_home }}

--- a/ansible/roles/mesos/templates/quorum
+++ b/ansible/roles/mesos/templates/quorum
@@ -1,0 +1,1 @@
+{{ mesos_quorum }}

--- a/ansible/roles/mesos/templates/zk
+++ b/ansible/roles/mesos/templates/zk
@@ -1,0 +1,1 @@
+{{ mesos_zookeeper_connect }}

--- a/bin/impl/zetten/config.py
+++ b/bin/impl/zetten/config.py
@@ -17,7 +17,7 @@ from util import get_num_ephemeral, exit, get_arch, get_ami
 import os
 from os.path import join
 
-SERVICES = ['zookeeper', 'namenode', 'resourcemanager', 'accumulomaster', 'worker', 'fluo', 'metrics']
+SERVICES = ['zookeeper', 'namenode', 'resourcemanager', 'accumulomaster', 'mesosmaster', 'worker', 'fluo', 'metrics']
 
 class DeployConfig(ConfigParser):
 
@@ -52,7 +52,7 @@ class DeployConfig(ConfigParser):
       self.get_image_id(self.get('ec2', 'worker_instance_type'))
 
       for service in SERVICES:
-        if service not in ['fluo', 'metrics']:
+        if service not in ['fluo', 'metrics', 'mesosmaster']:
           if not self.has_service(service):
             exit("ERROR - Missing '{0}' service from [nodes] section of zetten.props".format(service))
 

--- a/conf/zetten.props.example
+++ b/conf/zetten.props.example
@@ -140,13 +140,18 @@ fluo_worker_threads=64
 fluo_worker_instances_multiplier=2
 yarn_nm_mem_mb=16384
 
+[ansible-vars]
+# This section is used to override Ansible variables. Any variable set below will be placed in the hosts file created by Zetten.
+# Expected format:  variable = value
+
 [nodes]
 # Describes nodes in cluster in the following format: 
 # <Hostname> = <Service1>[,<Service2>,<Service3>]
 # Where: 
 #   Hostname = Must be unique.  Will be used for hostname in EC2 or should match hostname on your own cluster
-#   Service = Service to run on node (possible values: zookeeper, namenode, resourcemanager, accumulomaster, worker, fluo, metrics)
-#             All services are required below except for fluo & metrics which are optional
+#   Service = Service to run on node (possible values: zookeeper, namenode, resourcemanager, accumulomaster,
+#             mesosmaster, worker, fluo, metrics)
+#   All services are required below except for mesosmaster, fluo & metrics which are optional
 leader1 = namenode,zookeeper,fluo
 leader2 = resourcemanager,zookeeper
 leader3 = accumulomaster,zookeeper


### PR DESCRIPTION
 * Zetten can now optionally setup Apache Mesos.
 * Users can also override Ansible variables using zetten.props.
 * The ansible site.yml is built to only include task files of
   services that should be started to reduce skip messages in
   Ansible logs